### PR TITLE
Document memory store database lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ Rich markup escaping on all LLM output; command chaining splits on `&&`/`||`/`;`
 - `agent/loop.py` — ReAct loop with safety, sudo retry, engine fallback, small-context filtering, edit failure tracking
 - `agent/system_prompt.py` — Platform-aware system prompt with behavior rules and `/no_think` directive
 - `agent/context.py` — System context gathering (CPU, RAM, disk, network, services, containers)
-- `agent/context_manager.py` — Token budget management, message trimming, `/compact` summarization
+- `agent/context_manager.py` — Token budget management, message trimming, `/compact` summarization, `build_summary_with_refs()` for retrieval-augmented compaction
+- `agent/memory_store.py` — SQLite chunk store backing retrieval-augmented compaction. Content-addressed (SHA256 of role + tool_name + content), FTS5 search with LIKE fallback, session-scoped via join table. Limits: 50 MB / 30 d / 64 KB per chunk; oversize chunks truncated head/tail at `put()`. `gc()` (LRU eviction) and `delete_session()` are defined but **not wired to any automatic caller** in the current release — store grows until `store.db` is manually removed. Disables itself after 3 consecutive SQLite failures; `compact_history()` then falls back to legacy summary.
 - `agent/plan.py` — Markdown plan parser, extracts `PlanStep` from H2 headings
 - `agent/plan_executor.py` — Step-by-step plan execution with per-step agent budgets
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ The agent has access to 12 tools:
 ### Backup & Undo
 Every file edit creates a timestamped backup in `~/.local/share/natshell/backups/`. Use `/undo` to restore the most recent edit. Backups are pruned to 10 per file by default.
 
+### Memory Store (Retrieval-Augmented Compaction)
+When `/compact` (or automatic compaction) drops older messages to free context window space, their full content is written to a content-addressed SQLite chunk store instead of being discarded. The short summary that replaces them contains `[mem:<hash>]` references, and the agent can call the `recall_memory` tool to fetch full content on demand. If a later user message mentions a filename captured in a stored chunk, the chunk is auto-rehydrated inline so smaller models don't need to reason about calling `recall_memory` themselves.
+
+**Storage layout:**
+- Database: `~/.local/share/natshell/memory/store.db` (SQLite, WAL mode; parent dir `0o700`)
+- Schema: a `chunks` table keyed by SHA256 of `role + tool_name + content` (identical content deduplicates across sessions), a `chunk_sessions` join table scoping chunks to a session, and an optional FTS5 virtual table for full-text search (falls back to `LIKE` when FTS5 is unavailable)
+
+**Limits and lifecycle (`[memory_store]` in `config.default.toml`):**
+
+| Setting | Default | Behavior when exceeded |
+|---------|---------|------------------------|
+| `chunk_max_bytes` | 64 KB (65536) | Oversize content is truncated head/tail at write time with a `[... N bytes elided ...]` marker and stored |
+| `max_size_mb` | 50 MB | `MemoryStore.gc()` runs LRU eviction (ranked by most recent `last_accessed` across sessions, oldest first) until the store is under budget |
+| `max_age_days` | 30 days | `MemoryStore.gc()` deletes any chunk whose `created_at` is older than the cutoff |
+
+**How "full" is handled:** the `chunk_max_bytes` cap is enforced inline on every `put()` — oversize chunks are always truncated before storage, never rejected. The `max_size_mb` and `max_age_days` caps are only enforced when `MemoryStore.gc()` is called.
+
+**When the database is cleared:** `gc()` and `delete_session()` are exposed as public APIs on `MemoryStore`, but in the current release **neither is wired to an automatic trigger** — no startup hook, no post-compaction hook, no slash command, and no call from `SessionManager.delete`. In practice the database grows until you manually remove `store.db`, and chunks scoped to a deleted session are not pruned when the session file is deleted. Passive growth control comes only from content-hash deduplication via `INSERT OR IGNORE` — re-reading the same file repeatedly collapses to a single chunk.
+
+**Failure isolation:** every public `MemoryStore` method catches exceptions. After 3 consecutive SQLite failures the store disables itself (`healthy = False`) and `compact_history()` falls back to the legacy extractive summary; the agent loop is never broken by a storage error. Set `enabled = false` under `[memory_store]` to opt out entirely.
+
 ### Session Persistence
 Save and restore conversations with `/save`, `/load`, and `/sessions`. Sessions are stored as JSON in `~/.local/share/natshell/sessions/`.
 


### PR DESCRIPTION
Add a README section and CLAUDE.md module entry describing the retrieval-augmented compaction SQLite chunk store introduced in the previous commit. Covers storage location, schema, per-chunk/store/age limits, failure isolation, and the current gap that gc() and delete_session() are defined but not wired to any automatic trigger — so the store grows until store.db is manually removed.

Documentation only; no code changes.