### PR TITLE
security: bind argument names before classifying, not after

### DIFF
--- a/src/natshell/agent/loop.py
+++ b/src/natshell/agent/loop.py
@@ -790,6 +790,22 @@ class AgentLoop:
                     yield AgentEvent(type=EventType.PLANNING, data=result.content)
 
                 for tool_call in result.tool_calls:
+                    # Bind the arguments to their parameter names *before*
+                    # classifying, so the classifier judges the call that will
+                    # actually run.  execute() repairs misnamed parameters by
+                    # position, which used to happen after this point: a model
+                    # that wrote "cmd" instead of "command" -- a mistake the
+                    # remap exists because small models make constantly -- got
+                    # classified against an absent key and ran unconfirmed.
+                    #
+                    # Assigning back onto the call also makes the confirmation
+                    # dialog show the arguments the tool will receive.
+                    normalized = self.tools.normalize_arguments(
+                        tool_call.name, tool_call.arguments
+                    )
+                    if normalized is not None:
+                        tool_call.arguments = normalized
+
                     # Safety classification
                     risk = self.safety.classify_tool_call(tool_call.name, tool_call.arguments)
                     logger.debug(

--- a/src/natshell/mcp_server.py
+++ b/src/natshell/mcp_server.py
@@ -59,6 +59,13 @@ async def _execute_tool(
     """Execute a NatShell tool with safety classification, returning MCP content."""
     from mcp.types import TextContent
 
+    # Bind the arguments to their parameter names before classifying, so the
+    # classifier judges the call that will actually run rather than the model's
+    # raw one -- execute() repairs misnamed parameters by position.
+    normalized = registry.normalize_arguments(name, arguments)
+    if normalized is not None:
+        arguments = normalized
+
     # Safety check
     risk = safety.classify_tool_call(name, arguments)
 

--- a/src/natshell/tools/registry.py
+++ b/src/natshell/tools/registry.py
@@ -159,32 +159,27 @@ class ToolRegistry:
             )
 
         # ── Step 1: validate arguments against the handler signature ──
-        # ``sig.bind`` raises TypeError on unknown kwargs or missing
-        # required args, but does NOT execute the handler body.  This
-        # lets us separate "bad arg names" from "handler crashed mid-run".
-        try:
-            inspect.signature(handler).bind(**arguments)
-        except TypeError:
-            remapped = self._remap_arguments(name, arguments)
-            if remapped is None:
-                defn = self._definitions.get(name)
-                expected = (
-                    list(defn.parameters.get("properties", {}).keys()) if defn else []
-                )
-                return ToolResult(
-                    output="",
-                    error=f"Tool error: wrong arguments for {name}. "
-                    f"Got: {list(arguments.keys())}. "
-                    f"Expected: {expected}",
-                    exit_code=1,
-                )
+        normalized = self.normalize_arguments(name, arguments)
+        if normalized is None:
+            defn = self._definitions.get(name)
+            expected = (
+                list(defn.parameters.get("properties", {}).keys()) if defn else []
+            )
+            return ToolResult(
+                output="",
+                error=f"Tool error: wrong arguments for {name}. "
+                f"Got: {list(arguments.keys())}. "
+                f"Expected: {expected}",
+                exit_code=1,
+            )
+        if normalized is not arguments:
             logger.warning(
                 "Tool %s: remapped bad arg names %s → %s",
                 name,
                 list(arguments.keys()),
-                list(remapped.keys()),
+                list(normalized.keys()),
             )
-            arguments = remapped
+        arguments = normalized
 
         # ── Step 2: execute the handler.  Any exception from here on is
         #    a runtime error inside the tool, not a kwarg problem. ──
@@ -197,6 +192,37 @@ class ToolRegistry:
                 error=f"Tool error: {type(e).__name__}: {e}",
                 exit_code=1,
             )
+
+    def normalize_arguments(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Return the arguments ``execute`` would really call *name* with.
+
+        Callers that inspect a tool call before running it -- the safety
+        classifier above all -- have to judge this dict rather than the model's
+        raw one.  ``execute`` repairs misnamed parameters by position, so the
+        two can differ: ``execute_shell({"cmd": "rm -rf /"})`` carries no
+        "command" key, and a classifier reading ``arguments["command"]`` sees an
+        empty string, matches no pattern, and approves a call that then runs
+        with the name supplied.
+
+        Returns None when the call cannot be repaired; ``execute`` turns that
+        into a wrong-arguments error, and a caller classifying beforehand should
+        treat it as the unrunnable call it is.
+        """
+        handler = self._tools.get(name)
+        if handler is None:
+            return None
+        # ``sig.bind`` raises TypeError on unknown kwargs or missing required
+        # args, but does NOT execute the handler body.  This lets us separate
+        # "bad arg names" from "handler crashed mid-run".
+        try:
+            inspect.signature(handler).bind(**arguments)
+        except TypeError:
+            return self._remap_arguments(name, arguments)
+        return arguments
 
     def _remap_arguments(
         self,

--- a/tests/test_argument_normalization.py
+++ b/tests/test_argument_normalization.py
@@ -1,0 +1,165 @@
+"""Arguments must be bound to parameter names *before* they are classified.
+
+The registry repairs a tool call whose argument names are wrong by zipping the
+values onto the expected keys by position.  That repair used to happen inside
+execute(), after the safety classifier had already run and passed judgement on
+the unrepaired names — so the classifier read arguments.get("command", "") from
+a dict with no "command" key, saw an empty string, matched nothing, and
+returned SAFE.  The registry then supplied the missing name and ran it.
+
+That defeats CONFIRM and BLOCKED alike, on one token the model gets wrong for
+its own reasons rather than an attacker's.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from natshell.agent.context import SystemContext
+from natshell.agent.loop import AgentLoop, EventType
+from natshell.config import AgentConfig, SafetyConfig
+from natshell.inference.engine import CompletionResult, ToolCall
+from natshell.safety.classifier import Risk, SafetyClassifier
+from natshell.tools.registry import create_default_registry
+
+# The names small models actually confabulate, from the tool-call training data
+# of whichever shell tool they saw most.
+WRONG_NAMES = ["cmd", "shell_command", "bash_command", "input"]
+
+
+class TestNormalizeArguments:
+    def test_correct_arguments_pass_through_unchanged(self):
+        registry = create_default_registry()
+        args = {"command": "ls -la"}
+        assert registry.normalize_arguments("execute_shell", args) == args
+
+    @pytest.mark.parametrize("wrong", WRONG_NAMES)
+    def test_wrong_name_is_bound_to_the_real_parameter(self, wrong):
+        registry = create_default_registry()
+        normalized = registry.normalize_arguments("execute_shell", {wrong: "ls -la"})
+        assert normalized == {"command": "ls -la"}
+
+    def test_unmappable_arguments_return_none(self):
+        registry = create_default_registry()
+        assert (
+            registry.normalize_arguments("execute_shell", {"a": 1, "b": 2, "c": 3})
+            is None
+        )
+
+    def test_unknown_tool_returns_none(self):
+        """No handler means no signature to bind against, so nothing to promise."""
+        registry = create_default_registry()
+        assert registry.normalize_arguments("no_such_tool", {"whatever": 1}) is None
+
+
+class TestClassificationSeesNormalizedArguments:
+    """The property that matters: classify and execute must read the same call."""
+
+    @pytest.mark.parametrize("wrong", WRONG_NAMES)
+    def test_blocked_command_under_a_wrong_name_is_blocked(self, wrong):
+        registry = create_default_registry()
+        safety = SafetyClassifier(
+            SafetyConfig(mode="confirm", always_confirm=[], blocked=[r"^rm\s+-rf\s+/\s*$"])
+        )
+        normalized = registry.normalize_arguments("execute_shell", {wrong: "rm -rf /"})
+        assert safety.classify_tool_call("execute_shell", normalized) == Risk.BLOCKED
+
+    @pytest.mark.parametrize(
+        "tool,wrong_args,expected",
+        [
+            ("execute_shell", {"cmd": "rm notes.txt"}, Risk.CONFIRM),
+            ("write_file", {"file": "/tmp/x", "text": "hi"}, Risk.CONFIRM),
+            ("read_file", {"file": "/home/u/.ssh/id_rsa"}, Risk.CONFIRM),
+        ],
+    )
+    def test_risk_bearing_tools_under_wrong_names(self, tool, wrong_args, expected):
+        registry = create_default_registry()
+        safety = SafetyClassifier(
+            SafetyConfig(mode="confirm", always_confirm=[r"^rm\s"], blocked=[])
+        )
+        normalized = registry.normalize_arguments(tool, wrong_args)
+        assert safety.classify_tool_call(tool, normalized) == expected
+
+    def test_unnormalized_call_is_what_the_bug_looked_like(self):
+        """Documents the defect: the raw dict really does classify SAFE."""
+        safety = SafetyClassifier(
+            SafetyConfig(mode="confirm", always_confirm=[], blocked=[r"^rm\s+-rf\s+/\s*$"])
+        )
+        assert safety.classify_tool_call("execute_shell", {"cmd": "rm -rf /"}) == Risk.SAFE
+
+
+def _agent_emitting(tool_call: ToolCall) -> AgentLoop:
+    engine = AsyncMock()
+    engine.chat_completion = AsyncMock(
+        side_effect=[
+            CompletionResult(tool_calls=[tool_call]),
+            CompletionResult(content="done"),
+        ]
+    )
+    safety = SafetyClassifier(
+        SafetyConfig(
+            mode="confirm",
+            always_confirm=[r"^rm\s"],
+            blocked=[r"^rm\s+-[rR]f\s+/\s*$"],
+        )
+    )
+    agent = AgentLoop(
+        engine=engine,
+        tools=create_default_registry(),
+        safety=safety,
+        config=AgentConfig(max_steps=5, temperature=0.3, max_tokens=256),
+    )
+    agent.initialize(
+        SystemContext(
+            hostname="testhost",
+            distro="Debian 13",
+            kernel="6.12.0",
+            username="testuser",
+        )
+    )
+    return agent
+
+
+async def _events(agent: AgentLoop, confirm_callback=None) -> list[EventType]:
+    return [
+        event.type
+        async for event in agent.handle_user_message(
+            "go", confirm_callback=confirm_callback
+        )
+    ]
+
+
+class TestAgentLoopNormalizesBeforeClassifying:
+    async def test_blocked_command_under_a_wrong_name_never_executes(self):
+        agent = _agent_emitting(
+            ToolCall(id="1", name="execute_shell", arguments={"cmd": "rm -rf /"})
+        )
+        types = await _events(agent)
+        assert EventType.BLOCKED in types
+        assert EventType.EXECUTING not in types
+
+    async def test_confirm_command_under_a_wrong_name_prompts(self):
+        agent = _agent_emitting(
+            ToolCall(id="1", name="execute_shell", arguments={"cmd": "rm notes.txt"})
+        )
+        seen: list[ToolCall] = []
+
+        async def confirm(tool_call):
+            seen.append(tool_call)
+            return False
+
+        types = await _events(agent, confirm_callback=confirm)
+        assert EventType.CONFIRM_NEEDED in types
+        assert EventType.EXECUTING not in types
+        # The dialog must show the call as it will run, not as the model wrote it.
+        assert seen and seen[0].arguments == {"command": "rm notes.txt"}
+
+    async def test_safe_command_under_a_wrong_name_still_runs(self):
+        agent = _agent_emitting(
+            ToolCall(id="1", name="execute_shell", arguments={"cmd": "echo hi"})
+        )
+        types = await _events(agent)
+        assert EventType.EXECUTING in types
+        assert EventType.BLOCKED not in types


### PR DESCRIPTION
Closes #27. First of the six from your review of #26, one fix per PR as asked.

## The bug

`ToolRegistry.execute` repairs a tool call whose argument names are wrong by zipping values onto the expected keys by position — but that ran *after* `classify_tool_call` had already passed judgement. Two different dicts.

`execute_shell({"cmd": "..."})` has no `"command"` key, so the classifier matched an empty string against every pattern, returned `SAFE`, skipped both the `BLOCKED` and `CONFIRM` branches, and then `execute` supplied the missing name and ran it.

## The fix

`normalize_arguments()` is the binding step lifted out of `execute()` so callers who inspect a call before running it see what will actually run. `loop.py` and `mcp_server.py` call it before classifying and assign the result back onto the call — which also makes the confirmation dialog show the arguments the tool will receive rather than the ones the model wrote.

| | |
|---|---|
| `tools/registry.py` | +35 −1 — extraction, not new logic |
| `agent/loop.py` | +14 |
| `mcp_server.py` | +7 |
| `tests/test_argument_normalization.py` | +165 |

You estimated ~30 lines and this is 56. The extra is `registry.py`: rather than calling the bind logic twice I pulled it into one method both paths use, so classify and execute cannot drift apart again. Happy to inline it if you'd rather.

The MCP call site isn't in your issue text, but it's the same bypass through the other transport, so it's here too.

## Testing

16 of the 18 new tests fail against unmodified `main`. The 2 that pass are `test_unnormalized_call_is_what_the_bug_looked_like` (documents the defect — passes before and after by design) and `test_safe_command_under_a_wrong_name_still_runs` (non-regression).

Full suite, Windows and Linux, no new failures against `main`. `ruff check src/ tests/` clean.
