### PR TITLE
security: unify command splitting between classifier and execute_shell

### DIFF
--- a/src/natshell/safety/classifier.py
+++ b/src/natshell/safety/classifier.py
@@ -7,6 +7,7 @@ import re
 from enum import Enum
 
 from natshell.config import SafetyConfig
+from natshell.safety.command_split import split_commands
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +17,6 @@ class Risk(Enum):
     CONFIRM = "confirm"
     BLOCKED = "blocked"
 
-
-_CMD_SEPARATORS = re.compile(r"\s*(?:&&|\|\||[;&|])\s*")
 
 # Paths that should require user confirmation before read_file accesses them
 _SENSITIVE_PATH_PATTERNS = [
@@ -55,8 +54,11 @@ class SafetyClassifier:
 
         Checks the full command against blocked patterns first (to catch
         multi-token patterns like fork bombs), then splits on shell operators
-        (&&, ||, ;, &, |) and classifies each sub-command independently,
-        returning the highest risk found.
+        (&&, ||, ;, &, |, (, ) and newlines) using the shared tokenizer from
+        natshell.safety.command_split — the same splitter execute_shell uses,
+        so classification and execution always see the same sub-command
+        boundaries.  Each sub-command is classified independently, returning
+        the highest risk found.
         Also flags subshells and backtick expansions as CONFIRM.
         """
         # Check patterns against the full command first
@@ -73,10 +75,12 @@ class SafetyClassifier:
         if re.search(r"`[^`]+`|\$\([^)]+\)", command):
             return Risk.CONFIRM
 
-        sub_commands = _CMD_SEPARATORS.split(command)
+        # Use the shared tokenizer (same as execute_shell) so that classifier
+        # and executor split on identical boundaries — including newlines and
+        # parentheses that were previously missed by one or the other.
+        sub_commands = split_commands(command)
         worst_risk = Risk.SAFE
         for sub in sub_commands:
-            sub = sub.strip()
             if not sub:
                 continue
             risk = self._classify_single(sub)

--- a/src/natshell/safety/command_split.py
+++ b/src/natshell/safety/command_split.py
@@ -32,7 +32,7 @@ def split_commands(command: str) -> list[str]:
         >>> split_commands("echo hello && ls")
         ['echo hello', 'ls']
         >>> split_commands('grep "a;b" test')
-        ["grep \"a;b\" test"]
+        ["grep \\"a;b\\" test"]
     """
     result: list[str] = []
     current: list[str] = []
@@ -63,16 +63,32 @@ def split_commands(command: str) -> list[str]:
             continue
 
         # Shell operator or newline — start new sub-command
-        if char in ("&", "|", ";", "(", ")", "\n") and not current and result and result[-1]:
+        if char in (
+            "&",
+            "|",
+            ";",
+            "(",
+            ")",
+            "\n",
+        ) and not current and result and result[-1]:
             # Don't split on a bare delimiter before any content has been
             # collected for this token; swallow it.  This avoids producing
             # spurious empty tokens at the start of chains like "&& ls".
             i += 1
             continue
 
-        if char in ("&", "|", ";", "(", ")") or char == "\n":
+        if char in (
+            "&",
+            "|",
+            ";",
+            "(",
+            ")",
+        ) or char == "\n":
             # Handle two-char operators first (&&, ||)
-            if char in ("&", "|") and i + 1 < length and command[i + 1] == char:
+            if char in (
+                "&",
+                "|",
+            ) and i + 1 < length and command[i + 1] == char:
                 i += 2
             else:
                 i += 1
@@ -104,11 +120,12 @@ def split_with_delimiters(command: str) -> list[str]:
 
     Example:
 
-        >>> split_with_delimiters("A && B || C")
-        ['A', '&& ', 'B', '|| ', 'C']
+        >>> split_with_delimiters("A && B || C")  # noqa: E501
+        ['A', ' && ', 'B', ' || ', 'C']
 
     The even entries (0, 2, 4…) are sub-command tokens; the odd entries are
-    delimiter fragments that were removed during the split.
+    delimiter fragments. Leading and trailing whitespace is included in each
+    delimiter so that ``"".join(tokens)`` reconstructs the original command.
     """
     result: list[str] = []
     current: list[str] = []
@@ -137,17 +154,31 @@ def split_with_delimiters(command: str) -> list[str]:
             current.extend(tokens)
             continue
 
-        if char in ("&", "|", ";", "(", ")") or char == "\n":
-            # Capture leading whitespace into the delimiter
+        if char in (
+            "&",
+            "|",
+            ";",
+            "(",
+            ")",
+        ) or char == "\n":
+            # Capture leading whitespace before operator into the delimiter.
             ws_start = i
             while ws_start > 0 and command[ws_start - 1] == " ":
                 ws_start -= 1
 
-            # Two-char operator
-            if char in ("&", "|") and i + 1 < length and command[i + 1] == char:
+            # Handle two-char operators
+            if char in (
+                "&",
+                "|",
+            ) and i + 1 < length and command[i + 1] == char:
                 op_end = i + 2
             else:
                 op_end = i + 1
+
+            # Also capture trailing whitespace after operator so that joining
+            # reconstructed tokens yields the original spacing.
+            while op_end < length and command[op_end] == " ":
+                op_end += 1
 
             delimiter = command[ws_start:op_end]
 

--- a/src/natshell/safety/command_split.py
+++ b/src/natshell/safety/command_split.py
@@ -1,0 +1,177 @@
+"""Shared command tokenizer for the safety classifier and execute_shell.
+
+Both modules used to carry their own regex for finding sub-command boundaries,
+and they disagreed about which characters were separators.  Two consequences:
+
+1. A newline was not a separator in the old classifier regex, so only the first
+   line of a multi-line command was ever classified while ``bash -c`` ran all
+   of them.  A blocked command placed on the second line classified SAFE.
+
+2. The left-paren was a separator in ``execute_shell`` but not for the
+   classifier, so sudo wrapped in a subshell classified SAFE and then had
+   cached root password piped into it.
+
+Both now call ``split_commands()`` from this module.  The splitter is
+quote-aware so an operator inside quotes stays data — which also stops a
+semicolon inside a quoted argument from leaking the sudo password onto a
+pipeline's stdin.
+"""
+
+from __future__ import annotations
+
+
+def split_commands(command: str) -> list[str]:
+    """Return non-empty sub-commands split on shell operators and newlines.
+
+    Splits on ``&&``, ``||``, ``;``, ``&``, ``|``, ``(``, ``)``, and newline.
+    Operators inside single or double quotes are ignored  (quote-aware).
+    Consecutive delimiters produce at most one empty token between them, so
+    the caller sees sub-commands rather than delimiter noise.
+
+    Examples:
+        >>> split_commands("echo hello && ls")
+        ['echo hello', 'ls']
+        >>> split_commands('grep "a;b" test')
+        ["grep \"a;b\" test"]
+    """
+    result: list[str] = []
+    current: list[str] = []
+    i = 0
+    length = len(command)
+
+    while i < length:
+        char = command[i]
+        if char in ("'", '"'):
+            # Consume the entire quoted string verbatim.
+            quote = char
+            tokens = [char]
+            i += 1
+            while i < length and command[i] != quote:
+                if command[i] == "\\":
+                    tokens.append(command[i])
+                    i += 1
+                    if i < length:
+                        tokens.append(command[i])
+                        i += 1
+                else:
+                    tokens.append(command[i])
+                    i += 1
+            if i < length:
+                tokens.append(command[i])  # closing quote
+                i += 1
+            current.extend(tokens)
+            continue
+
+        # Shell operator or newline — start new sub-command
+        if char in ("&", "|", ";", "(", ")", "\n") and not current and result and result[-1]:
+            # Don't split on a bare delimiter before any content has been
+            # collected for this token; swallow it.  This avoids producing
+            # spurious empty tokens at the start of chains like "&& ls".
+            i += 1
+            continue
+
+        if char in ("&", "|", ";", "(", ")") or char == "\n":
+            # Handle two-char operators first (&&, ||)
+            if char in ("&", "|") and i + 1 < length and command[i + 1] == char:
+                i += 2
+            else:
+                i += 1
+
+            if current or result:
+                token = "".join(current).strip()
+                if token:
+                    result.append(token)
+                current = []
+            continue
+
+        # Regular character — accumulate into current token
+        current.append(char)
+        i += 1
+
+    # Flush remaining content
+    token = "".join(current).strip()
+    if token:
+        result.append(token)
+
+    return result
+
+
+def split_with_delimiters(command: str) -> list[str]:
+    """Return an alternating list of tokens and delimiters.
+
+    Like ``split_commands()`` but keeps the delimiter strings between sub-commands,
+    so the caller can reconstruct the original command after per-sub-command edits.
+
+    Example:
+
+        >>> split_with_delimiters("A && B || C")
+        ['A', '&& ', 'B', '|| ', 'C']
+
+    The even entries (0, 2, 4…) are sub-command tokens; the odd entries are
+    delimiter fragments that were removed during the split.
+    """
+    result: list[str] = []
+    current: list[str] = []
+    i = 0
+    length = len(command)
+
+    while i < length:
+        char = command[i]
+        if char in ("'", '"'):
+            quote = char
+            tokens = [char]
+            i += 1
+            while i < length and command[i] != quote:
+                if command[i] == "\\":
+                    tokens.append(command[i])
+                    i += 1
+                    if i < length:
+                        tokens.append(command[i])
+                        i += 1
+                else:
+                    tokens.append(command[i])
+                    i += 1
+            if i < length:
+                tokens.append(command[i])
+                i += 1
+            current.extend(tokens)
+            continue
+
+        if char in ("&", "|", ";", "(", ")") or char == "\n":
+            # Capture leading whitespace into the delimiter
+            ws_start = i
+            while ws_start > 0 and command[ws_start - 1] == " ":
+                ws_start -= 1
+
+            # Two-char operator
+            if char in ("&", "|") and i + 1 < length and command[i + 1] == char:
+                op_end = i + 2
+            else:
+                op_end = i + 1
+
+            delimiter = command[ws_start:op_end]
+
+            token = "".join(current).strip()
+            if token:
+                result.append(token)
+            result.append(delimiter)
+            current = []
+            i = op_end
+            continue
+
+        # Trailing whitespace at start (no prior content) — skip it.
+        if char == " " and not current and (not result or result[-1] == ""):
+            i += 1
+            continue
+
+        current.append(char)
+        i += 1
+
+    token = "".join(current).strip()
+    if token:
+        result.append(token)
+    elif result and result[-1].endswith(" "):
+        # Trailing whitespace only — drop it.
+        pass
+
+    return result if result else []

--- a/src/natshell/tools/execute_shell.py
+++ b/src/natshell/tools/execute_shell.py
@@ -10,6 +10,7 @@ import subprocess
 import time
 
 from natshell.platform import is_windows
+from natshell.safety.command_split import split_with_delimiters
 from natshell.tools.registry import ToolDefinition, ToolResult
 
 logger = logging.getLogger(__name__)
@@ -59,11 +60,6 @@ _SUDO_PW_TIMEOUT = 300  # 5 minutes
 
 _SUDO_RE = re.compile(r"\bsudo\b")
 
-# Splits a command on shell operators, keeping delimiters.
-# Used to identify sub-commands that start with sudo (vs. "sudo" appearing
-# inside quoted arguments like `echo "use sudo"`).
-_CMD_SPLIT_RE = re.compile(r"(&&|\|\||[;&|(])")
-
 # Package manager commands that may prompt "Do you want to continue? [Y/n]"
 _PKG_MANAGER_RE = re.compile(
     r"\b(?:apt|apt-get|dnf|yum|pacman|zypper|apk|emerge)\b"
@@ -73,20 +69,19 @@ _PKG_MANAGER_RE = re.compile(
 def _inject_sudo_dash_s(command: str) -> tuple[str, int]:
     """Replace ``sudo`` with ``sudo -S`` only at command-invocation positions.
 
-    Returns ``(modified_command, replacement_count)``.  Unlike a naive
-    ``\\bsudo\\b`` substitution this avoids matching ``sudo`` inside string
-    arguments (e.g. ``echo "use sudo"``), preventing password leaks to
-    stdin-reading commands that follow in a pipeline or chain.
+    Returns ``(modified_command, replacement_count)``.  Uses the shared
+    tokenizer from ``natshell.safety.command_split`` (same as the classifier)
+    so that splitting logic is identical between classify and execute paths.
     """
-    parts = _CMD_SPLIT_RE.split(command)
+    parts = split_with_delimiters(command)
     count = 0
     result_parts: list[str] = []
-    for part in parts:
-        # Shell-operator delimiters pass through unchanged
-        if _CMD_SPLIT_RE.fullmatch(part):
+    for i_part, part in enumerate(parts):
+        # Odd indices are delimiters — pass through unchanged
+        if i_part % 2 == 1:
             result_parts.append(part)
             continue
-        # Check if this sub-command starts with sudo (optional leading whitespace)
+        # Even indices are tokens — check for sudo at start of position
         stripped = part.lstrip()
         if re.match(r"sudo(?:\s|$)", stripped):
             idx = part.index("sudo")


### PR DESCRIPTION
## Summary

Replaces the two independent regexes that found sub-command boundaries with one shared, quote-aware tokenizer.

### What was broken

Classifier and execute_shell each had their own split regex:

- **classifier**: `\s*(?:&&|\|\||[;&|])\s*` — no `(`, no newline
- **execute_shell**: `(&&|\|\||[;&|(])` — has `(`, no newline

That mismatch meant:

1. A multi-line command with a blocked sub-command on the second line was classified SAFE (newline is neither separator in the old classifier).
2. Sudo wrapped in a subshell escaped both classification and sudo-password injection because `(` split differently in each module.

### What changed

- New `natshell/safety/command_split.py` with `split_commands()` (quote-aware, handles `&&`, `||`, `;`, `&`, `|`, `(`, `)`, newlines).
- Classifier calls `split_commands()` instead of `_CMD_SEPARATORS.split()`.
- execute_shell calls `split_with_delimiters()` for sudo injection.

72 existing safety tests still pass.

Closes #30