### PR TITLE
security: remove _is_agents_md exemption and reject symlinks on writes

### DIFF
--- a/src/natshell/safety/classifier.py
+++ b/src/natshell/safety/classifier.py
@@ -34,12 +34,6 @@ _SENSITIVE_PATH_PATTERNS = [
 ]
 
 
-def _is_agents_md(path: str) -> bool:
-    """Return True if *path* is a working memory agents.md file."""
-    return (
-        path.endswith(".natshell/agents.md")
-        or path.endswith(".config/natshell/agents.md")
-    )
 
 
 class SafetyClassifier:
@@ -121,8 +115,6 @@ class SafetyClassifier:
 
         if tool_name == "write_file":
             path = arguments.get("path", "")
-            if _is_agents_md(path):
-                return Risk.SAFE
             for pattern in _SENSITIVE_PATH_PATTERNS:
                 if pattern in path:
                     return Risk.CONFIRM
@@ -133,8 +125,6 @@ class SafetyClassifier:
         if tool_name == "edit_file":
             # Always confirm edits; also check sensitive paths
             path = arguments.get("path", "")
-            if _is_agents_md(path):
-                return Risk.SAFE
             for pattern in _SENSITIVE_PATH_PATTERNS:
                 if pattern in path:
                     return Risk.CONFIRM

--- a/src/natshell/tools/edit_file.py
+++ b/src/natshell/tools/edit_file.py
@@ -164,7 +164,14 @@ async def edit_file(
     end_line: int | None = None,
 ) -> ToolResult:
     """Replace a unique occurrence of old_text with new_text in a file."""
-    target = Path(path).expanduser().resolve()
+    raw = Path(path).expanduser()
+
+    # Refuse to follow symlinks — prevents editing an arbitrary target through
+    # a symlink (e.g. /tmp/evil/.natshell/agents.md -> ~/.bashrc)
+    if raw.is_symlink():
+        return ToolResult(error=f"Symlink not allowed: {raw}", exit_code=1)
+
+    target = raw.resolve()
 
     if not target.exists():
         return ToolResult(error=f"File not found: {target}", exit_code=1)

--- a/src/natshell/tools/write_file.py
+++ b/src/natshell/tools/write_file.py
@@ -40,7 +40,14 @@ DEFINITION = ToolDefinition(
 
 async def write_file(path: str, content: str, mode: str = "overwrite") -> ToolResult:
     """Write content to a file."""
-    target = Path(path).expanduser().resolve()
+    raw = Path(path).expanduser()
+
+    # Refuse to follow symlinks — prevents writing through a symlink to an
+    # arbitrary target (e.g. /tmp/evil/.natshell/agents.md -> ~/.bashrc)
+    if raw.is_symlink():
+        return ToolResult(error=f"Symlink not allowed: {raw}", exit_code=1)
+
+    target = raw.resolve()
 
     try:
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -273,7 +273,8 @@ def test_memory_config_in_natshell_config() -> None:
 # ── Safety exemption ─────────────────────────────────────────────────
 
 
-def test_safety_exempts_agents_md_write() -> None:
+def test_safety_agents_md_write_is_confirm() -> None:
+    """agents.md writes are no longer SAFE; they go through normal CONFIRM gating."""
     from natshell.config import SafetyConfig
     from natshell.safety.classifier import Risk, SafetyClassifier
 
@@ -281,10 +282,11 @@ def test_safety_exempts_agents_md_write() -> None:
     risk = sc.classify_tool_call(
         "write_file", {"path": "/home/user/project/.natshell/agents.md"}
     )
-    assert risk == Risk.SAFE
+    assert risk == Risk.CONFIRM
 
 
-def test_safety_exempts_agents_md_edit() -> None:
+def test_safety_agents_md_edit_is_confirm() -> None:
+    """agents.md edits are no longer SAFE; they go through normal CONFIRM gating."""
     from natshell.config import SafetyConfig
     from natshell.safety.classifier import Risk, SafetyClassifier
 
@@ -292,7 +294,7 @@ def test_safety_exempts_agents_md_edit() -> None:
     risk = sc.classify_tool_call(
         "edit_file", {"path": "/home/user/.config/natshell/agents.md"}
     )
-    assert risk == Risk.SAFE
+    assert risk == Risk.CONFIRM
 
 
 def test_safety_still_confirms_other_writes() -> None:


### PR DESCRIPTION
## Summary

Removes the  function from the classifier and adds symlink rejection at the tool level.

### What was broken

 returned  for any path ending in , regardless of actual content or whether the path was a real agents.md file. This meant an attacker could write to arbitrary files through a symlink like:



The classifier would see `.natshell/agents.md` in the suffix and return `SAFE`, while `write_file` would follow the symlink and overwrite the target.

### What changed

- **classifier.py**: Deleted  and both uses (lines 124, 136). agents.md paths now go through normal CONFIRM/BLOCKED classification based on actual content and sensitivity patterns.
- **write_file.py / edit_file.py**: Added symlink check before resolving the path. If the raw expanded path is a symlink, the tool returns an error immediately rather than following it.

72 existing safety tests pass.

Closes #28