### PR TITLE
security: narrow update_config tool to non-sensitive config keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "llama-cpp-python>=0.3.20",
     "huggingface-hub>=0.24",
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio>=0.23",
     "ruff",
 ]
 

--- a/src/natshell/tools/update_config.py
+++ b/src/natshell/tools/update_config.py
@@ -6,7 +6,6 @@ import logging
 
 from natshell.config import (
     CONFIG_ENUMS,
-    VALID_CONFIG_KEYS,
     NatShellConfig,
     save_config_value,
 )

--- a/src/natshell/tools/update_config.py
+++ b/src/natshell/tools/update_config.py
@@ -14,7 +14,61 @@ from natshell.tools.registry import ToolDefinition, ToolResult
 
 logger = logging.getLogger(__name__)
 
-# ── Live config injection ─────────────────────────────────────────────────
+# ── Read-only/writable key split ────────────────────────────────────────
+
+# Keys the model is allowed to set via update_config.  Excluded are:
+# safety settings (could disable user protections), remote inference URL/api_key
+# (could redirect traffic / use a malicious backend), engine preference, MCP safety,
+# prompt persona (could override system instructions), and skills.enabled toggles.
+LLM_WRITABLE_KEYS: dict[str, dict[str, str]] = {
+    "model": {
+        "path": "str",
+        "hf_repo": "str",
+        "hf_file": "str",
+        "n_ctx": "int",
+        "n_threads": "int",
+        "n_gpu_layers": "int",
+        "main_gpu": "int",
+        "prompt_cache": "bool",
+        "prompt_cache_mb": "int",
+    },
+    "agent": {
+        "max_steps": "int",
+        "plan_max_steps": "int",
+        "temperature": "float",
+        "max_tokens": "int",
+        "context_reserve": "int",
+    },
+    "ui": {
+        "theme": "str",
+    },
+    "backup": {
+        "enabled": "bool",
+        "max_per_file": "int",
+    },
+    "kiwix": {
+        "url": "str",
+    },
+    "memory": {
+        "enabled": "bool",
+        "max_chars": "int",
+        "min_ctx": "int",
+    },
+    "skills": {
+        "disabled": "list",
+        "inject_in_compact": "bool",
+    },
+    "ollama": {
+        "url": "str",
+        "default_model": "str",
+        "n_ctx": "int",
+    },
+    "prompt": {
+        "extra_instructions": "str",
+    },
+}
+
+# ── Live config injection ───────────────────────────────────────────────
 
 _live_config: NatShellConfig | None = None
 
@@ -106,20 +160,20 @@ def _apply_to_live_config(
 
 async def update_config(section: str, key: str, value: str) -> ToolResult:
     """Validate, coerce, persist, and apply a config change."""
-    # Validate section
-    if section not in VALID_CONFIG_KEYS:
-        valid_sections = ", ".join(sorted(VALID_CONFIG_KEYS.keys()))
+    # Validate section + key — model is NOT allowed to change security-sensitive keys
+    if section not in LLM_WRITABLE_KEYS:
         return ToolResult(
-            error=f"Unknown config section: {section!r}. Valid sections: {valid_sections}",
+            error=(
+                f"Section [{section}] is read-only and cannot be changed by update_config. "
+                f"(Security-sensitive sections require manual edits to config.toml.)"
+            ),
             exit_code=1,
         )
 
-    # Validate key
-    section_keys = VALID_CONFIG_KEYS[section]
+    section_keys = LLM_WRITABLE_KEYS[section]
     if key not in section_keys:
-        valid_keys = ", ".join(sorted(section_keys.keys()))
         return ToolResult(
-            error=f"Unknown key {key!r} in [{section}]. Valid keys: {valid_keys}",
+            error=f"Key {key!r} cannot be changed by update_config.",
             exit_code=1,
         )
 

--- a/tests/test_update_config.py
+++ b/tests/test_update_config.py
@@ -286,38 +286,33 @@ class TestUpdateConfigTool:
         assert "0.7" in result.output
 
     @pytest.mark.asyncio
-    async def test_unknown_section(self):
+    async def test_readonly_section(self):
+        result = await update_config("safety", "danger_fast", "true")
+        assert result.exit_code == 1
+        assert "read-only" in result.error
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_section(self):
         result = await update_config("nonexistent", "key", "val")
         assert result.exit_code == 1
-        assert "Unknown config section" in result.error
+        assert "read-only" in result.error  # nonexistent sections treated as read-only
 
     @pytest.mark.asyncio
-    async def test_unknown_key(self):
-        result = await update_config("agent", "nonexistent", "val")
+    async def test_restricted_key(self):
+        """prompt.persona excluded; prompt.extra_instructions still works."""
+        result = await update_config("prompt", "persona", "evil")
         assert result.exit_code == 1
-        assert "Unknown key" in result.error
+        assert "cannot be changed" in result.error
 
     @pytest.mark.asyncio
-    async def test_type_mismatch(self):
-        result = await update_config("agent", "max_steps", "abc")
-        assert result.exit_code == 1
-        assert "integer" in result.error
-
-    @pytest.mark.asyncio
-    async def test_danger_fast_update(self):
-        result = await update_config("safety", "danger_fast", "true")
+    async def test_extra_instructions_ok(self):
+        result = await update_config("prompt", "extra_instructions", "be helpful")
         assert result.exit_code == 0
-        assert "danger_fast" in result.output
-
-    @pytest.mark.asyncio
-    async def test_enum_validation(self):
-        result = await update_config("safety", "mode", "invalid")
-        assert result.exit_code == 1
-        assert "Allowed values" in result.error
+        assert "extra_instructions" in result.output
 
     @pytest.mark.asyncio
     async def test_enum_valid(self):
-        result = await update_config("safety", "mode", "warn")
+        result = await update_config("ui", "theme", "dark")
         assert result.exit_code == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

The `update_config` tool now validates against a new `LLM_WRITABLE_KEYS` allowlist instead of the full `VALID_CONFIG_KEYS`. The following sections are **no longer modifiable** by the model:

- `[safety]`: mode, danger_fast
- `[remote]`: url, model, api_key, n_ctx
- `[engine]`: preferred
- `[mcp]`: safety_mode
- `[prompt].persona` (extra_instructions still allowed)

These require manual edits to `config.toml` instead.

**Why**: A compromised agent could disable user protections (`safety.mode = danger`), redirect traffic to a malicious inference backend, or override system prompts.

**Error messages**: Attempting to change a restricted section returns "read-only" with guidance to edit config.toml manually.