### PR TITLE
security: harden skill loading against project-local code execution

### DIFF
--- a/src/natshell/skills/__init__.py
+++ b/src/natshell/skills/__init__.py
@@ -195,15 +195,36 @@ def load_skills(tool_registry: ToolRegistry, config: NatShellConfig) -> SkillReg
             logger.warning("skipping skill %s: description must be one line", name)
             continue
 
+        # 3. Prevent shadowing: a project skill cannot override a builtin or user skill
+        if name in seen and source == "project" and seen[name].source != "project":
+            logger.warning(
+                "skipping project skill %s at %s: shadows existing %s skill",
+                name, skill_dir, seen[name].source,
+            )
+            continue
+
+        # 4. Check disabled before executing any Python code
+        #    (disabled flag was previously only consulted when listing for the model)
+        if name in disabled:
+            logger.info("skill %s is disabled — skipping exec_module", name)
+            seen[name] = Skill(name=name, description=desc, path=skill_dir, source=source)
+            continue
+
+        # 5. Build registry entry (later sources override earlier on collision)
         if name in seen:
             logger.info("skill %s: %s overrides %s", name, source, seen[name].source)
         seen[name] = Skill(name=name, description=desc, path=skill_dir, source=source)
 
+        # 6. Execute tools.py only for non-project skills
         tools_py = skill_dir / "tools.py"
         if source == "project":
             # project skills can only be injected as instructions (SKILL.md),
             # we do NOT run their Python code — arbitrary repos could supply malicious code
-            logger.info("skill %s: project-level tools.py not auto-executed", name)
+            logger.info(
+                "skill %s: project-level tools.py not auto-executed "
+                "(move it to ~/.config/natshell/skills/%s/tools.py if you want it loaded)",
+                name, name,
+            )
         elif tools_py.is_file():
             try:
                 spec = importlib.util.spec_from_file_location(

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -459,6 +459,74 @@ class TestLoadSkills:
         assert skill_reg.get("user-tool-skill") is not None
         assert "tools.py load failed" in caplog.text
 
+    def test_disabled_skill_skips_exec_module(self, tmp_path, caplog):
+        """Disabled skills must NOT have their tools.py run at all."""
+        d = _make_skill_dir(tmp_path, "nosafe", "A disabled skill", "Body here.")
+        (d / "tools.py").write_text("raise RuntimeError('executed despite disabled!')\n")
+        cfg = _make_config(disabled=["nosafe"])
+
+        registry = _make_tool_registry()
+
+        with patch("natshell.skills._iter_skill_dirs", return_value=[(d, "builtin")]):
+            from natshell.skills import load_skills
+
+            # Should NOT raise — exec_module is skipped for disabled skills
+            with caplog.at_level(logging.INFO):
+                skill_reg = load_skills(registry, cfg)
+
+        assert skill_reg.get("nosafe") is not None
+        assert "skipping exec_module" in caplog.text
+
+    def test_project_skill_cannot_shadow_builtin(self, tmp_path, caplog):
+        """A project-level skill with the same name as a builtin must be skipped."""
+        d_builtin = _make_skill_dir(
+            tmp_path / "builtin", "shared-skill", "Builtin version", "Builtin body."
+        )
+        d_project = _make_skill_dir(
+            tmp_path / "project", "shared-skill", "Project shadow", "Project body."
+        )
+
+        cfg = _make_config()
+        registry = _make_tool_registry()
+
+        with patch(
+            "natshell.skills._iter_skill_dirs",
+            return_value=[(d_builtin, "builtin"), (d_project, "project")],
+        ):
+            from natshell.skills import load_skills
+
+            with caplog.at_level(logging.WARNING):
+                skill_reg = load_skills(registry, cfg)
+
+        # Builtin should win — project version is rejected
+        s = skill_reg.get("shared-skill")
+        assert s is not None
+        assert s.source == "builtin"
+        assert "shadows existing" in caplog.text
+
+    def test_project_skill_override_another_project_allowed(self, tmp_path, caplog):
+        """Two project skills from different dirs can still override each other
+        (e.g., nested repos) — only cross-source shadowing is blocked."""
+        d1 = _make_skill_dir(tmp_path / "p1", "proj-skill", "Proj v1", "body")
+        d2 = _make_skill_dir(tmp_path / "p2", "proj-skill", "Proj v2", "body")
+
+        cfg = _make_config()
+        registry = _make_tool_registry()
+
+        with patch(
+            "natshell.skills._iter_skill_dirs",
+            return_value=[(d1, "project"), (d2, "project")],
+        ):
+            from natshell.skills import load_skills
+
+            skill_reg = load_skills(registry, cfg)
+
+        # Later project wins — not blocked because both are project-source
+        s = skill_reg.get("proj-skill")
+        assert s is not None
+        assert s.source == "project"
+        assert s.description == "Proj v2"
+
 
 # ---------------------------------------------------------------------------
 # skill tool handler


### PR DESCRIPTION
## What changed

Three gaps in skill discovery/loading were left open after PR #36/#38:

1. **Disabled skills still executed their `tools.py` at startup** — the ``disabled`` flag was only consulted when listing skills for the model, not before calling `exec_module()`. A user who ran `/skills disable x` still had that skill's Python run on every launch.

2. **Project-level skills could shadow builtin/user skill names** — cloning an attacker's repo into your CWD could silently replace a trusted tool definition with attacker-controlled code (e.g., replacing the `coding` skill name with evil ``tools.py``). Now cross-source name collisions are rejected with a warning.

3. **Project tools.py skip message had no migration path** — added guidance telling the user to copy the file to `~/.config/natshell/skills/<name>/tools.py`.

## Test Plan

- 61 skill tests pass on Python 3.12
- New tests:`\t`test_disabled_skill_skips_exec_module``, ``test_project_skill_cannot_shadow_builtin``, ``test_project_skill_override_another_project_allo``wed``

Closes #32