### PR TITLE
security: write config values as data, not as TOML source

### DIFF
--- a/src/natshell/config.py
+++ b/src/natshell/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import tempfile
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,6 +13,57 @@ from pathlib import Path
 from natshell.platform import config_dir as _platform_config_dir
 
 logger = logging.getLogger(__name__)
+
+
+def _toml_escape(s: str) -> str:
+    """Escape a Python string as a safe TOML basic-string literal.
+
+    Handles backslash, double-quote, and all control characters per the
+    TOML spec so no value can corrupt config syntax (or inject section
+    headers that bypass VALID_CONFIG_KEYS).
+    """
+    out = (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\b", "\\b")
+        .replace("\f", "\\f")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    escaped = []
+    for ch in out:
+        cp = ord(ch)
+        if cp < 0x20 or cp == 0x7F:
+            escaped.append(f"\\u{cp:04x}")
+        else:
+            escaped.append(ch)
+    return "\"{}\"".format("".join(escaped))
+
+
+def _write_config_atomically(path: Path, text: str) -> None:
+    """Write *text* to *path* via temp-file + os.replace after validating TOML.
+
+    If the rendered content is invalid TOML, the old file stays untouched and
+    a RuntimeError propagates instead of corrupting on-disk state.
+    """
+    try:
+        tomllib.loads(text)
+    except tomllib.TOMLDecodeError as e:
+        raise RuntimeError(f"Config would become invalid TOML: {e}") from e
+
+    dir_ = path.parent
+    fd, tmp = tempfile.mkstemp(dir=str(dir_), suffix=".toml")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _get_config_dir() -> Path:
@@ -245,11 +297,11 @@ def save_config_value(section: str, key: str, value: str | int | float | bool) -
     else:
         lines = []
 
-    # Format value as TOML
+    # Format value as TOML (strings are escaped to prevent injection)
     if isinstance(value, bool):
         val_str = "true" if value else "false"
     elif isinstance(value, str):
-        val_str = f'"{value}"'
+        val_str = _toml_escape(value)
     else:
         val_str = str(value)
 
@@ -284,7 +336,7 @@ def save_config_value(section: str, key: str, value: str | int | float | bool) -
         lines.append(f"\n{section_header}\n")
         lines.append(new_line)
 
-    config_path.write_text("".join(lines))
+    _write_config_atomically(config_path, "".join(lines))
     return config_path
 
 
@@ -346,9 +398,17 @@ _SECTIONS = (
 
 
 def _merge_toml(config: NatShellConfig, path: Path) -> None:
-    """Merge a TOML file into the config, overwriting only specified fields."""
-    with open(path, "rb") as f:
-        data = tomllib.load(f)
+    """Merge a TOML file into the config, overwriting only specified fields.
+
+    If *path* is unreadable or contains invalid TOML, log a warning and skip —
+    so a corrupted config file never prevents NatShell from starting.
+    """
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError) as e:
+        logger.error("Failed to load %s: %s — skipping.", path.name, e)
+        return
 
     for section_name in _SECTIONS:
         if section_name in data:
@@ -380,7 +440,7 @@ def save_skills_disabled(disabled: list[str]) -> Path:
     else:
         lines = []
 
-    items = ", ".join(f'"{n}"' for n in disabled)
+    items = ", ".join(_toml_escape(n) for n in disabled)
     val_str = f"[{items}]"
     key = "disabled"
     section_header = "[skills]"
@@ -413,7 +473,7 @@ def save_skills_disabled(disabled: list[str]) -> Path:
         lines.append(f"\n{section_header}\n")
         lines.append(new_line)
 
-    config_path.write_text("".join(lines))
+    _write_config_atomically(config_path, "".join(lines))
     return config_path
 
 

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -1,0 +1,188 @@
+"""Security tests for config writing: TOML escaping, atomic writes, and fault tolerance."""
+from __future__ import annotations
+
+import tomllib
+from unittest.mock import patch
+
+import pytest
+
+from natshell.config import (
+    NatShellConfig,
+    _merge_toml,
+    _toml_escape,
+    _write_config_atomically,
+    load_config,
+    save_config_value,
+    save_skills_disabled,
+)
+
+
+class TestTomlEscape:
+    """_toml_escape must handle every adversarial string."""
+
+    def test_plain(self):
+        assert _toml_escape("hello") == '"hello"'
+
+    def test_quote(self):
+        assert _toml_escape('say "hi"') == '"say \\"hi\\""'
+
+    def test_backslash(self):
+        escaped = _toml_escape(r"C:\Users\me")
+        assert escaped == r'"C:\\Users\\me"'
+
+    def test_newline(self):
+        assert _toml_escape("a\nb") == '"a\\nb"'
+
+    def test_tab(self):
+        assert _toml_escape("x\ty") == '"x\\ty"'
+
+    def test_control_char(self):
+        assert _toml_escape("a\x00b") == '"a\\u0000b"'
+
+    def test_del(self):
+        assert _toml_escape("foo\x7Fbar") == '"foo\\u007fbar"'
+
+    def test_roundtrips(self):
+        """Escaped string must parse back to the original via tomllib."""
+        samples = [
+            "hello",
+            "it's fine",
+            'say "bye"',
+            r"back\slash",
+            "line1\nline2",
+            "\tindented",
+            "ctrl\x01char",
+        ]
+        for raw in samples:
+            escaped = _toml_escape(raw)
+            parsed = tomllib.loads(f"key = {escaped}")
+            assert parsed["key"] == raw, f"Roundtrip failed for {raw!r}"
+
+    def test_injection_attempt(self):
+        """An injected section header must not render as a new TOML table."""
+        evil = '[safety]\nmode = "danger"\n'
+        escaped = _toml_escape(evil)
+        document = f"[model]\npath = {escaped}"
+        parsed = tomllib.loads(document)
+        assert "safety" not in parsed
+        assert parsed["model"]["path"] == evil
+
+
+class TestWriteConfigAtomically:
+    """Atomic writes must reject invalid TOML and leave no temp files."""
+
+    def test_valid_toml_succeeds(self, tmp_path):
+        dest = tmp_path / "ok.toml"
+        _write_config_atomically(dest, '[model]\npath = "foo"\n')
+        assert dest.exists()
+        data = tomllib.loads(dest.read_text())
+        assert data["model"]["path"] == "foo"
+
+    def test_invalid_toml_rejects(self, tmp_path):
+        dest = tmp_path / "bad.toml"
+        with pytest.raises(RuntimeError, match="invalid TOML"):
+            _write_config_atomically(dest, "[model\n")
+        assert not dest.exists()
+
+    def test_preserves_existing_on_failure(self, tmp_path):
+        dest = tmp_path / "keep.toml"
+        dest.write_text('[model]\npath = "original"\n')
+        with pytest.raises(RuntimeError):
+            _write_config_atomically(dest, "[broken\n")
+        assert dest.exists()
+        data = tomllib.loads(dest.read_text())
+        assert data["model"]["path"] == "original"
+
+    def test_no_temp_file_left(self, tmp_path):
+        dest = tmp_path / "clean.toml"
+        _write_config_atomically(dest, "[x]\ny = 1\n")
+        tomls = list(tmp_path.glob("*.toml"))
+        assert len(tomls) == 1
+        assert tomls[0].name == "clean.toml"
+
+
+class TestSaveConfigValueSecurity:
+    """save_config_value must escape strings — no raw interpolation."""
+
+    def _mock_dir(self, tmp_path):
+        return patch("natshell.config._get_config_dir", return_value=tmp_path)
+
+    def test_string_with_quotes_is_safe(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('[model]\npath = "original"\n')
+        with self._mock_dir(tmp_path):
+            save_config_value("model", "path", 'value with "quotes"')
+        data = tomllib.loads(cfg.read_text())
+        assert data["model"]["path"] == 'value with "quotes"'
+
+    def test_backslash_windows_path(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('[model]\npath = ""\n')
+        with self._mock_dir(tmp_path):
+            save_config_value("model", "path", r"C:\Users\test")
+        data = tomllib.loads(cfg.read_text())
+        assert data["model"]["path"] == r"C:\Users\test"
+
+    def test_injection_blocked(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('[model]\npath = ""\n[safety]\nmode = "warn"\n')
+        evil = 'x"\n[safety]\nmode = "danger"\n'
+        with self._mock_dir(tmp_path):
+            save_config_value("model", "path", evil)
+        data = tomllib.loads(cfg.read_text())
+        assert data["safety"]["mode"] == "warn"
+
+    def test_newstring_in_value_does_not_crash(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text("[agent]\ntemperature = 0.3\n")
+        with self._mock_dir(tmp_path):
+            save_config_value("agent", "temperature", 17)
+        data = tomllib.loads(cfg.read_text())
+        assert data["agent"]["temperature"] == 17
+
+
+class TestSaveSkillsDisabledSecurity:
+    """save_skills_disabled must escape skill names."""
+
+    def _mock_dir(self, tmp_path):
+        return patch("natshell.config._get_config_dir", return_value=tmp_path)
+
+    def test_normal_list(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        with self._mock_dir(tmp_path):
+            save_skills_disabled(["kiwix", "spotify"])
+        data = tomllib.loads(cfg.read_text())
+        assert data["skills"]["disabled"] == ["kiwix", "spotify"]
+
+    def test_name_with_quote_escaped(self, tmp_path):
+        cfg = tmp_path / "config.toml"
+        with self._mock_dir(tmp_path):
+            save_skills_disabled(['malicious"name'])
+        data = tomllib.loads(cfg.read_text())
+        assert data["skills"]["disabled"] == ['malicious"name']
+
+
+class TestLoadConfigFaultTolerance:
+    """_merge_toml must not crash on corrupted TOML."""
+
+    def test_bad_toml_skipped(self, tmp_path):
+        bad_cfg = tmp_path / "config.toml"
+        bad_cfg.write_text("[broken\n")
+        cfg = NatShellConfig()
+        _merge_toml(cfg, bad_cfg)
+        # Default values preserved — no crash
+        assert cfg.model.path == "auto"
+
+    def test_good_toml_merged(self, tmp_path):
+        good_cfg = tmp_path / "config.toml"
+        good_cfg.write_text('[agent]\nmax_steps = 42\n')
+        cfg = NatShellConfig()
+        _merge_toml(cfg, good_cfg)
+        assert cfg.agent.max_steps == 42
+
+    def test_load_config_with_bad_file(self, tmp_path):
+        bad_cfg = tmp_path / "config.toml"
+        bad_cfg.write_text("[unterminated\n")
+        cfg = load_config(bad_cfg)
+        # Gracefully returns defaults instead of crashing
+        assert isinstance(cfg, NatShellConfig)


### PR DESCRIPTION
## Summary

Fixes a vulnerability where arbitrary string values written to config.toml could corrupt or inject TOML sections.

### Changes

1. **Add `\`_toml_escape()\``** — properly escapes strings per the TOML spec (backslash, double-quote, and all control characters). Also fixes the ordinary bug that Windows paths like \`C:\\Users\\me\` were never valid unescaped TOML.

2. **Replace raw f-string interpolation** in \`save_config_value()\` and \`save_skills_disabled()\` with \`_toml_escape()\`. Previously a value containing quotes and newlines could close the string literal and inject arbitrary TOML sections — including \`[safety]\` mode = "danger".

3. **Add `\`_write_config_atomically()\``** — writes via temp file + \`os.replace\` after validating the rendered result parses as valid TOML. A bad write fails at point of writing with the old file left intact, instead of corrupting config at next launch.

4. **Catch \`TOMLDecodeError\` in `\`_merge_toml()\``** — a corrupted config file now logs an error and degrades to defaults rather than crashing on launch (DoS protection).

### Tests

22 new tests covering:
- TOML string escaping for all adversarial inputs
- Roundtrip parsing of escaped strings through \`tomllib\`
- Injection attempts (section headers embedded in values)
- Atomic write behavior (valid succeeds, invalid rejected, old file preserved)
- Fault-tolerant config loading

## Test Results

1490 tests passed (all green), 22 new security tests included.